### PR TITLE
feat: 프로젝트 탭 네비게이션 및 데이터 조회 API 추가

### DIFF
--- a/src/api/readPersonalProjects.action.ts
+++ b/src/api/readPersonalProjects.action.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { readAllProjects } from "@/api/readAllProjects.action";
+import { ProjectPayload } from "@/types";
+
+function countParticipants(
+  participants: ProjectPayload["participants"]
+): number {
+  if (!participants) return 0;
+  if (Array.isArray(participants)) return participants.length;
+  if (typeof participants === "object") return Object.keys(participants).length;
+  return 0;
+}
+
+export async function readPersonalProjects(): Promise<ProjectPayload[]> {
+  try {
+    const all = await readAllProjects();
+    return all.filter((p) => countParticipants(p.participants) < 2);
+  } catch (err) {
+    console.error("readPersonalProjects error:", err);
+    return [];
+  }
+}

--- a/src/api/readTeamProjects.action.ts
+++ b/src/api/readTeamProjects.action.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { readAllProjects } from "@/api/readAllProjects.action";
+import { ProjectPayload } from "@/types";
+
+function countParticipants(
+  participants: ProjectPayload["participants"]
+): number {
+  if (!participants) return 0;
+  if (Array.isArray(participants)) return participants.length;
+  if (typeof participants === "object") return Object.keys(participants).length;
+  return 0;
+}
+
+export async function readTeamProjects(): Promise<ProjectPayload[]> {
+  try {
+    const all = await readAllProjects();
+    return all.filter((p) => countParticipants(p.participants) >= 2);
+  } catch (err) {
+    console.error("readTeamProjects error:", err);
+    return [];
+  }
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,3 +1,39 @@
-export default function ProjectsPage() {
-  return <div>Project</div>;
+import AllProjectsTab from "@/components/domain/projects/AllProjectsTab";
+import PersonalProjectsTab from "@/components/domain/projects/PersonalProjectsTab";
+import ProjectsTabNavigation from "@/components/domain/projects/ProjectsTabNavigation";
+import TeamProjectsTab from "@/components/domain/projects/TeamProjectsTab";
+import { redirect } from "next/navigation";
+
+export default async function ProjectsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const { tab } = await searchParams;
+
+  if (!tab) {
+    redirect("?tab=1");
+  }
+
+  let content;
+  switch (tab) {
+    case "1":
+      content = <AllProjectsTab />;
+      break;
+    case "2":
+      content = <TeamProjectsTab />;
+      break;
+    case "3":
+      content = <PersonalProjectsTab />;
+      break;
+    default:
+      redirect("?tab=1");
+  }
+
+  return (
+    <>
+      <ProjectsTabNavigation />
+      {content}
+    </>
+  );
 }

--- a/src/components/domain/projects/AllProjectsTab.tsx
+++ b/src/components/domain/projects/AllProjectsTab.tsx
@@ -1,0 +1,17 @@
+import { readAllProjects } from "@/api/readAllProjects.action";
+
+export default async function AllProjectsTab() {
+  const datas = await readAllProjects();
+  console.log(datas);
+  return (
+    <>
+      {datas.length === 0 ? (
+        <div className="text-center text-14-medium md:text-16-medium">
+          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+        </div>
+      ) : (
+        <div></div>
+      )}
+    </>
+  );
+}

--- a/src/components/domain/projects/PersonalProjectsTab.tsx
+++ b/src/components/domain/projects/PersonalProjectsTab.tsx
@@ -1,0 +1,19 @@
+import { readPersonalProjects } from "@/api/readPersonalProjects.action";
+
+export default async function PersonalProjectsTab() {
+  const datas = await readPersonalProjects();
+
+  console.log(datas);
+
+  return (
+    <>
+      {datas.length === 0 ? (
+        <div className="text-center text-12-medium md:text-14-medium">
+          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+        </div>
+      ) : (
+        <div></div>
+      )}
+    </>
+  );
+}

--- a/src/components/domain/projects/ProjectsTabNavigation.tsx
+++ b/src/components/domain/projects/ProjectsTabNavigation.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const tabs = [
+  { id: "1", label: "A L L\u00A0\u00A0\u00A0P R O J E C T S" },
+  { id: "2", label: "T E A M\u00A0\u00A0\u00A0P R O J E C T S" },
+  { id: "3", label: "P E R S O N A L\u00A0\u00A0\u00A0P R O J E C T S" },
+];
+
+export default function ProjectsTabNavigation() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentTab = searchParams.get("tab") ?? "1";
+
+  const handleTabClick = (id: string) => {
+    router.push(`?tab=${id}`);
+  };
+
+  return (
+    <div className="mb-12 md:mb-16 lg:mb-20 flex gap-x-4 md:gap-x-8 lg:gap-x-12 gap-y-3 flex-wrap justify-center text-14-semibold md:text-16-semibold">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => handleTabClick(tab.id)}
+          className={`relative
+          ${
+            currentTab === tab.id
+              ? "after:absolute after:left-0 after:bottom-0 after:h-0.25 after:w-full after:bg-black-100"
+              : "opacity-80"
+          }
+      `}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/domain/projects/TeamProjectsTab.tsx
+++ b/src/components/domain/projects/TeamProjectsTab.tsx
@@ -1,0 +1,18 @@
+import { readTeamProjects } from "@/api/readTeamProjects.action";
+
+export default async function TeamProjectsTab() {
+  const datas = await readTeamProjects();
+  console.log(datas);
+
+  return (
+    <>
+      {datas.length === 0 ? (
+        <div className="text-center text-14-medium md:text-16-medium">
+          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+        </div>
+      ) : (
+        <div></div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 작업 개요

- 프로젝트 목록을 탭으로 구분하여 조회할 수 있는 네비게이션 컴포넌트 추가
- 개인 / 팀 프로젝트 조회 API 구현
- 모든 / 팀 / 개인 프로젝트를 전환할 수 있는 구조 세팅

---

## 작업 상세 내용
- [x] AllProjectsTab, TeamProjectsTab, PersonalProjectsTab 컴포넌트 생성
- [x] ProjectsTabNavigation 컴포넌트 추가 (탭 전환 기능)
- [x] readPersonalProjects.action.ts, readTeamProjects.action.ts API 작성
- [x] projects/page.tsx 에서 searchParams 기반 탭 렌더링 적용

---

## 수정한 파일

- `src/app/projects/page.tsx`

## 새로 작성한 파일
- `src/api/readPersonalProjects.action.ts`
- `src/api/readTeamProjects.action.ts`
- `src/components/domain/projects/AllProjectsTab.tsx`
- `src/components/domain/projects/TeamProjectsTab.tsx`
- `src/components/domain/projects/PersonalProjectsTab.tsx`
- `src/components/domain/projects/ProjectsTabNavigation.tsx`