### PR TITLE
feat: 프로젝트 상세 페이지 완성 및 탭별 prev/next 이동 로직 수정

### DIFF
--- a/src/api/readAdjacentProjects.action.ts
+++ b/src/api/readAdjacentProjects.action.ts
@@ -4,8 +4,36 @@ import { database } from "@/firebase/firebaseConfig";
 import { ref, get, query, orderByChild } from "firebase/database";
 import type { ProjectPayload } from "@/types";
 
+/** participants 안전 카운트 (object | array | undefined 모두 처리) */
+function countParticipants(
+  participants: ProjectPayload["participants"]
+): number {
+  if (!participants) return 0;
+  if (Array.isArray(participants)) return participants.length;
+  if (typeof participants === "object") return Object.keys(participants).length;
+  return 0;
+}
+
+/** 탭 번호에 맞춰 프로젝트 리스트 필터링 */
+function filterByTab(
+  projects: ProjectPayload[],
+  tab: "1" | "2" | "3"
+): ProjectPayload[] {
+  switch (tab) {
+    case "2": // TEAM PROJECTS → 참여자 2명 이상
+      return projects.filter((p) => countParticipants(p.participants) >= 2);
+    case "3": // PERSONAL PROJECTS → 참여자 1명 이하
+      return projects.filter((p) => countParticipants(p.participants) < 2);
+    case "1": // ALL PROJECTS
+    default:
+      return projects;
+  }
+}
+
+/** 현재 프로젝트 기준 prev / next 찾기 */
 export async function readAdjacentProjects(
-  id: string
+  id: string,
+  tab: "1" | "2" | "3" = "1"
 ): Promise<{ prev: ProjectPayload | null; next: ProjectPayload | null }> {
   try {
     const projectsRef = ref(database, "projects");
@@ -14,20 +42,21 @@ export async function readAdjacentProjects(
 
     if (!snap.exists()) return { prev: null, next: null };
 
-    // 전체 프로젝트 배열로 변환 후 createdAt 기준 정렬
-    const allProjects = Object.values(snap.val()) as ProjectPayload[];
-    allProjects.sort(
+    // 전체 프로젝트 → 탭 필터링 → createdAt 기준 정렬
+    let list = Object.values(snap.val()) as ProjectPayload[];
+    list = filterByTab(list, tab);
+    list.sort(
       (a, b) =>
         new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
     );
 
     // 현재 프로젝트 위치 찾기
-    const idx = allProjects.findIndex((p) => p.id === id);
+    const idx = list.findIndex((p) => p.id === id);
     if (idx === -1) return { prev: null, next: null };
 
     return {
-      prev: idx < allProjects.length - 1 ? allProjects[idx + 1] : null,
-      next: idx > 0 ? allProjects[idx - 1] : null,
+      prev: idx < list.length - 1 ? list[idx + 1] : null,
+      next: idx > 0 ? list[idx - 1] : null,
     };
   } catch (err) {
     console.error("readAdjacentProjects error:", err);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ export default async function HomePage() {
         ${idx >= 3 ? "lg:hidden" : ""} /* lg 이상에서는 3개까지만 */
       `}
             >
-              <ProjectCard data={data} />
+              <ProjectCard data={data} currentTab="1" />
             </div>
           ))}
         </div>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -14,12 +14,17 @@ const positionOrder: Record<string, number> = {
 
 export default async function ProjectDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
 }) {
   const { id } = await params;
+  const { tab } = await searchParams;
+  const currentTab = (tab as "1" | "2" | "3") ?? "1";
+
   const data = await readProjectById(id);
-  const adjacent = await readAdjacentProjects(id);
+  const adjacent = await readAdjacentProjects(id, currentTab);
 
   if (!data) notFound();
   return (
@@ -27,7 +32,7 @@ export default async function ProjectDetailPage({
       <div className="hidden w-40 lg:block lg:fixed top-1/2 left-0 z-30 -translate-y-1/2">
         {adjacent.prev && (
           <Link
-            href={`/projects/${adjacent.prev.id}`}
+            href={`/projects/${adjacent.prev.id}?tab=${currentTab}`}
             className="group block relative overflow-hidden"
           >
             <Image
@@ -48,7 +53,7 @@ export default async function ProjectDetailPage({
       <div className="hidden w-40 lg:block lg:fixed top-1/2 -translate-y-1/2 right-0  z-30">
         {adjacent.next && (
           <Link
-            href={`/projects/${adjacent.next.id}`}
+            href={`/projects/${adjacent.next.id}?tab=${currentTab}`}
             className="group block relative overflow-hidden"
           >
             <Image

--- a/src/components/common/ProjectCard.tsx
+++ b/src/components/common/ProjectCard.tsx
@@ -3,17 +3,26 @@ import Image from "next/image";
 import Link from "next/link";
 import { FaArrowRightLong } from "react-icons/fa6";
 
-export default function ProjectCard({ data }: { data: ProjectPayload }) {
+export default function ProjectCard({
+  data,
+  currentTab,
+}: {
+  data: ProjectPayload;
+  currentTab: string;
+}) {
   return (
-    <Link href={`/projects/${data.id}`} className="block group ">
-      <div className="relative ">
+    <Link
+      href={`/projects/${data.id}?tab=${currentTab}`}
+      className="block group "
+    >
+      <div className="relative w-fit">
         <Image
           src={data.projectImageUrl}
           alt="projectImageUrl"
           width={370}
           height={0}
           unoptimized
-          className="block "
+          className="block"
         />
         <div
           className="

--- a/src/components/domain/projects/AllProjectsTab.tsx
+++ b/src/components/domain/projects/AllProjectsTab.tsx
@@ -1,8 +1,8 @@
 import { readAllProjects } from "@/api/readAllProjects.action";
+import ProjectCard from "@/components/common/ProjectCard";
 
 export default async function AllProjectsTab() {
   const datas = await readAllProjects();
-  console.log(datas);
   return (
     <>
       {datas.length === 0 ? (
@@ -10,7 +10,11 @@ export default async function AllProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div></div>
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+          {datas.map((data) => (
+            <ProjectCard key={data.id} data={data} currentTab="1" />
+          ))}
+        </div>
       )}
     </>
   );

--- a/src/components/domain/projects/PersonalProjectsTab.tsx
+++ b/src/components/domain/projects/PersonalProjectsTab.tsx
@@ -1,9 +1,8 @@
 import { readPersonalProjects } from "@/api/readPersonalProjects.action";
+import ProjectCard from "@/components/common/ProjectCard";
 
 export default async function PersonalProjectsTab() {
   const datas = await readPersonalProjects();
-
-  console.log(datas);
 
   return (
     <>
@@ -12,7 +11,11 @@ export default async function PersonalProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div></div>
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+          {datas.map((data) => (
+            <ProjectCard key={data.id} data={data} currentTab="3" />
+          ))}
+        </div>
       )}
     </>
   );

--- a/src/components/domain/projects/TeamProjectsTab.tsx
+++ b/src/components/domain/projects/TeamProjectsTab.tsx
@@ -1,8 +1,8 @@
 import { readTeamProjects } from "@/api/readTeamProjects.action";
+import ProjectCard from "@/components/common/ProjectCard";
 
 export default async function TeamProjectsTab() {
   const datas = await readTeamProjects();
-  console.log(datas);
 
   return (
     <>
@@ -11,7 +11,11 @@ export default async function TeamProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div></div>
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+          {datas.map((data) => (
+            <ProjectCard key={data.id} data={data} currentTab="2" />
+          ))}
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## 작업 개요

- 프로젝트 상세 페이지 UI 및 기능 구현
- All/Team/Personal 탭별 prev/next 이동 시 컨텍스트에 맞는 프로젝트만 탐색되도록 로직 수정

---

## 작업 상세 내용
- [x] ProjectCard 컴포넌트에서 탭 정보 전달 기능 추가
- [x] readAdjacentProjects 함수 수정 → 탭별 프로젝트 필터링(prev/next 계산 개선)
- [x] AllProjectsTab / TeamProjectsTab / PersonalProjectsTab 수정

---

## 수정한 파일
- `src/api/readAdjacentProjects.action.ts`
- `src/app/page.tsx`
- `src/app/projects/[id]/page.tsx`
- `src/components/common/ProjectCard.tsx`
- `src/components/domain/projects/AllProjectsTab.tsx`
- `src/components/domain/projects/PersonalProjectsTab.tsx`
- `src/components/domain/projects/TeamProjectsTab.tsx`


---

## 기타 참고 사항
- prev/next 이동 시 현재 탭 컨텍스트 유지

---

## 작업 스크린샷
<img width="1920" height="2100" alt="image" src="https://github.com/user-attachments/assets/f53c2346-447d-4814-8b42-2732a693c172" />


