### PR TITLE
feat: hero-banner 컴포넌트에서  참가자 hover 시 툴팁 표시 기능 추가

### DIFF
--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -63,16 +63,30 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
       <div className="bg-bg-300 -mx-5 py-10 px-5 lg:bg-bg-100 lg:w-180 lg:mx-auto lg:px-0 lg:hidden">
         <div className="flex justify-center ">
           {participants.map((participant) => (
-            <div key={participant.id} className="flex">
+            <div key={participant.id} className="flex relative group">
               {participant.imageUrl && (
-                <a href={participant.githubUrl} target="_blank">
-                  <Image
-                    src={participant.imageUrl}
-                    alt={`${participant.name}`}
-                    width={40}
-                    height={40}
-                  />
-                </a>
+                <>
+                  <a href={participant.githubUrl} target="_blank">
+                    <Image
+                      src={participant.imageUrl}
+                      alt={`${participant.name}`}
+                      width={40}
+                      height={40}
+                    />
+                  </a>
+
+                  {/* 툴팁 */}
+                  <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+                    <div className="flex flex-col gap-1.5 items-center bg-black-100 text-white  text-14-regular  shadow px-3 py-2 rounded-lg  whitespace-nowrap">
+                      {participant.name}
+                      <span className="text-12-regular">
+                        {participant.role}
+                      </span>
+                      {/* 화살표 */}
+                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-black-100"></div>
+                    </div>
+                  </div>
+                </>
               )}
             </div>
           ))}


### PR DESCRIPTION
## 작업 개요

- HeroBanner에서 참가자 프로필 hover 시 이름/role을 툴팁으로 표시하는 기능 추가


---

## 작업 상세 내용
- [x] 참가자 프로필 이미지 hover 시 툴팁 표시 (이름/role)
- [x] 모바일/태블릿 환경에서도 정상 작동하도록 반응형 적용

---

## 수정한 파일
- `src/components/domain/home/HeroBanner.tsx`


---

## 기타 참고 사항
- 추후 참가자 데이터에 role 값이 없을 경우 fallback 문구 적용 필요



---

## 작업 스크린샷

<img width="1587" height="2100" alt="image" src="https://github.com/user-attachments/assets/a1c3fa2b-7029-424d-b751-9d6ec0b44eb0" />
