### PR TITLE
refactor: HeroBanner컴포넌트  next/link를 i18n Link로 교체

### DIFF
--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -1,6 +1,6 @@
 import { ProjectPayload } from "@/types";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import badge from "@/assets/images/badge.svg";
 import { MdInsights } from "react-icons/md";
 import { getTranslations } from "next-intl/server";


### PR DESCRIPTION
## 작업 개요

- HeroBanner 컴포넌트에서 `next/link`를 `i18n Link`로 교체하여 다국어 라우팅 일관성을 유지

---

## 작업 상세 내용
- [x] HeroBanner 내부 링크 컴포넌트 교체 (`next/link` → `i18n Link`)
- [x] 다국어 라우팅 규칙을 적용하여 locale prefix 자동 반영
- [x] 불필요한 `next/link` import 제거

---

## 수정한 파일
- `src/components/domain/home/HeroBanner.tsx`


---

## 기타 참고 사항
- 기능 변경 없이 코드 구조 개선만 이루어짐

