### PR TITLE
feat: CreateForm.tsx 다국어 입력 지원을 위해 EN/KR 필드 분리 및 관련 페이지 수정

### DIFF
--- a/src/api/createProject.action.ts
+++ b/src/api/createProject.action.ts
@@ -19,11 +19,33 @@ export async function createProject(
     const id = crypto.randomUUID();
     const createdAt = new Date().toISOString();
 
-    // 기본 필드
-    const title = String(formData.get("title") || "").trim();
-    const tagline = String(formData.get("tagline") || "").trim();
-    const platform = String(formData.get("platform") || "").trim();
-    const description = String(formData.get("description") || "").trim();
+    // 다국어 필드
+    const title = {
+      en: String(formData.get("title_en") || "").trim(),
+      ko: String(formData.get("title_ko") || "").trim(),
+    };
+
+    const tagline = {
+      en: String(formData.get("tagline_en") || "").trim(),
+      ko: String(formData.get("tagline_ko") || "").trim(),
+    };
+
+    const platform = {
+      en: String(formData.get("platform_en") || "").trim(),
+      ko: String(formData.get("platform_ko") || "").trim(),
+    };
+
+    const description = {
+      en: String(formData.get("description_en") || "").trim(),
+      ko: String(formData.get("description_ko") || "").trim(),
+    };
+
+    const category = {
+      en: String(formData.get("category_en") || "").trim(),
+      ko: String(formData.get("category_ko") || "").trim(),
+    };
+
+    // 단일 필드
     const projectUrl = String(formData.get("projectUrl") || "").trim();
     const projectGitHubUrl = String(
       formData.get("projectGitHubUrl") || ""
@@ -31,8 +53,6 @@ export async function createProject(
     const projectImageUrl = String(
       formData.get("projectImageUrl") || ""
     ).trim();
-
-    const category = String(formData.get("category") || "").trim();
 
     // 태그
     const tagsRaw = String(formData.get("tags") || "");
@@ -78,10 +98,11 @@ export async function createProject(
     const payload: ProjectPayload = {
       id,
       createdAt,
-      title,
-      tagline,
-      platform,
-      description,
+      title, // { en, ko }
+      tagline, // { en, ko }
+      platform, // { en, ko }
+      description, // { en, ko }
+      category, // { en, ko }
       projectUrl,
       projectImageUrl,
       projectGitHubUrl,
@@ -89,7 +110,6 @@ export async function createProject(
       accessibilityScore,
       seoScore,
       overallScore,
-      category,
       tags,
       participants,
     };

--- a/src/app/[locale]/projects/[id]/page.tsx
+++ b/src/app/[locale]/projects/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { readAdjacentProjects } from "@/api/readAdjacentProjects.action";
 import { readProjectById } from "@/api/readProject.action";
 import Shortcut from "@/components/domain/projects/Shortcut";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getLocale } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -21,6 +21,7 @@ export default async function ProjectDetailPage({
   searchParams: Promise<{ tab?: string }>;
 }) {
   const t = await getTranslations("ProjectsPage.detail");
+  const locale = (await getLocale()) as "en" | "ko";
   const { id } = await params;
   const { tab } = await searchParams;
   const currentTab = (tab as "1" | "2" | "3") ?? "1";
@@ -76,9 +77,11 @@ export default async function ProjectDetailPage({
       <div className="max-w-185 mx-auto">
         <div className="flex  items-center justify-center  flex-col md:flex-row md:justify-between  md:items-center  mb-7">
           <div className="text-center md:text-left">
-            <h2 className="text-22-bold md:text-24-bold mb-2">{data.title}</h2>
+            <h2 className="text-22-bold md:text-24-bold mb-2">
+              {data.title[locale]}
+            </h2>
             <h3 className="text-14-regular md:text-18-regular">
-              {data.tagline} | {data.platform}
+              {data.tagline[locale]} | {data.platform[locale]}
             </h3>
           </div>
           <div className="pt-6">
@@ -101,7 +104,7 @@ export default async function ProjectDetailPage({
           <div>
             <h4 className="text-center md:text-left ">
               <span className="text-12-bold">{t("labels.about")}: </span>
-              <em className="text-12-regular">{data.description}</em>
+              <em className="text-12-regular">{data.description[locale]}</em>
             </h4>
           </div>
           <div className="md:flex md:flex-col-reverse md:justify-between md:min-w-4/10">
@@ -116,7 +119,7 @@ export default async function ProjectDetailPage({
             </h4>
             <h4 className="text-center md:text-left">
               <span className="text-12-bold">{t("labels.category")}: </span>
-              <span className="text-12-regular">{data.category}</span>
+              <span className="text-12-regular">{data.category[locale]}</span>
             </h4>
           </div>
         </div>

--- a/src/components/common/ProjectCard.tsx
+++ b/src/components/common/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { ProjectPayload } from "@/types";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getLocale } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
 import { FaArrowRightLong } from "react-icons/fa6";
@@ -12,10 +12,11 @@ export default async function ProjectCard({
   currentTab: string;
 }) {
   const t = await getTranslations("ProjectsPage");
+  const locale = (await getLocale()) as "en" | "ko";
   return (
     <Link
       href={`/projects/${data.id}?tab=${currentTab}`}
-      className="block group "
+      className="group flex flex-col  justify-center"
     >
       <div className="relative w-fit">
         <Image
@@ -41,8 +42,8 @@ export default async function ProjectCard({
         </div>
       </div>
 
-      <h4 className="pt-2 md:pt-3 text-14-semibold md:text-16-semibold uppercase">
-        {data.title} - {data.tagline}
+      <h4 className="max-w-92.5 pt-2 md:pt-3 text-14-semibold  md:text-16-semibold  line-clamp-2">
+        {data.title[locale]} - {data.tagline[locale]}
       </h4>
     </Link>
   );

--- a/src/components/domain/create/CreateForm.tsx
+++ b/src/components/domain/create/CreateForm.tsx
@@ -102,9 +102,31 @@ export default function CreateProjectForm() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
             <label className="block">
-              <span>PROJECT NAME</span>
+              <label className="block">
+                <span>PROJECT NAME (EN)</span>
+                <input
+                  name="title_en"
+                  type="text"
+                  required
+                  className="w-full border  border-line-100 rounded px-3 py-2"
+                />
+              </label>
+            </label>
+
+            <label className="block">
+              <span>PROJECT NAME (KO)</span>
               <input
-                name="title"
+                name="title_ko"
+                type="text"
+                required
+                className="w-full border  border-line-100 rounded px-3 py-2"
+              />
+            </label>
+
+            <label className="block">
+              <span>TAGLINE (EN)</span>
+              <input
+                name="tagline_en"
                 type="text"
                 required
                 className="w-full border border-line-100 rounded px-3 py-2"
@@ -112,9 +134,19 @@ export default function CreateProjectForm() {
             </label>
 
             <label className="block">
-              <span>TAGLINE</span>
+              <span>TAGLINE (KO)</span>
               <input
-                name="tagline"
+                name="tagline_ko"
+                type="text"
+                required
+                className="w-full border border-line-100 rounded px-3 py-2"
+              />
+            </label>
+
+            <label className="block ">
+              <span>PLATFORM (EN)</span>
+              <input
+                name="platform_en"
                 type="text"
                 required
                 className="w-full border border-line-100 rounded px-3 py-2"
@@ -122,31 +154,52 @@ export default function CreateProjectForm() {
             </label>
 
             <label className="block">
-              <span>PLATFORM</span>
+              <span>PLATFORM (KO)</span>
               <input
-                name="platform"
+                name="platform_ko"
                 type="text"
                 required
                 className="w-full border border-line-100 rounded px-3 py-2"
               />
             </label>
 
-            <label className="block">
-              <span>CATEGORY</span>
+            <label className="block ">
+              <span>CATEGORY (EN)</span>
               <input
-                name="category"
+                name="category_en"
                 type="text"
                 required
                 className="w-full border border-line-100 rounded px-3 py-2"
                 placeholder="E.G., SERVICE, TRAVEL, OTHERS"
               />
             </label>
+
+            <label className="block ">
+              <span>CATEGORY (KO)</span>
+              <input
+                name="category_ko"
+                type="text"
+                required
+                className="w-full border border-line-100 rounded px-3 py-2"
+                placeholder="예: 서비스, 여행, 기타"
+              />
+            </label>
           </div>
 
+          {/* DESCRIPTION */}
           <label className="block mt-4">
-            <span>DESCRIPTION</span>
+            <span>DESCRIPTION (EN)</span>
             <textarea
-              name="description"
+              name="description_en"
+              rows={3}
+              className="text-14-regular md:text-16-regular w-full border border-line-100 rounded px-3 py-2"
+            />
+          </label>
+
+          <label className="block mt-4">
+            <span>DESCRIPTION (KO)</span>
+            <textarea
+              name="description_ko"
               rows={3}
               className="text-14-regular md:text-16-regular w-full border border-line-100 rounded px-3 py-2"
             />

--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -3,11 +3,11 @@ import Image from "next/image";
 import { Link } from "@/i18n/routing";
 import badge from "@/assets/images/badge.svg";
 import { MdInsights } from "react-icons/md";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getLocale } from "next-intl/server";
 
 export default async function HeroBanner({ data }: { data: ProjectPayload }) {
   const t = await getTranslations("HomePage");
-
+  const locale = (await getLocale()) as "en" | "ko";
   // participants가 배열이면 그대로, 객체면 Object.values로 배열화, 없으면 빈 배열
   const participants = Array.isArray(data.participants)
     ? data.participants
@@ -40,15 +40,15 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
             />
             <div className="flex flex-col items-center md:items-start ">
               <h3 className="text-18-bold mb-2 lg:text-20-bold">
-                {data.title}
+                {data.title[locale]}
               </h3>
               <h4 className="text-14-regular lg:text-16-regular">
-                {data.tagline}
+                {data.tagline[locale]}
               </h4>
               <span className="text-14-regular lg:text-16-regular">-</span>
               <span className="text-14-regular lg:text-16-regular">
                 {" "}
-                {data.platform}
+                {data.platform[locale]}
               </span>
             </div>
           </div>
@@ -56,7 +56,7 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
           <div className="px-10 md:px-0 md:flex items-center justify-center md:w-50 lg:w-70">
             <p className="text-center md:text-left">
               <em className="text-12-regular lg:text-14-regular ">
-                {data.description}
+                {data.description[locale]}
               </em>
             </p>
           </div>

--- a/src/types/common/project.type.ts
+++ b/src/types/common/project.type.ts
@@ -11,10 +11,11 @@ export interface Participant {
 export interface ProjectPayload {
   id: string;
   createdAt: string;
-  title: string;
-  tagline: string;
-  platform: string;
-  description: string;
+  title: { en: string; ko: string };
+  tagline: { en: string; ko: string };
+  platform: { en: string; ko: string };
+  description: { en: string; ko: string };
+  category: { en: string; ko: string };
   projectUrl: string;
   projectImageUrl: string;
   projectGitHubUrl: string;
@@ -22,7 +23,6 @@ export interface ProjectPayload {
   accessibilityScore: number;
   seoScore: number;
   overallScore: number;
-  category: string;
   tags: string[];
   participants: Record<string, Participant> | Participant[];
 }


### PR DESCRIPTION
## 작업 개요
- CreateForm.tsx에 다국어 입력(EN/KR) 필드 분리 적용  
- 프로젝트 생성/상세/카드/배너 등 관련 페이지 전체 수정  
---

## 작업 상세 내용
- [x] CreateForm.tsx 내 다국어 입력 필드 분리 (EN/KR)  
- [x] HeroBanner, ProjectCard 등 다국어 데이터 연동  
- [x] 프로젝트 상세 페이지 다국어 데이터 반영  
- [x] 프로젝트 타입 정의(`project.type.ts`) 수정 

---

## 수정한 파일
- `src/api/createProject.action.ts`  
- `src/app/[locale]/projects/[id]/page.tsx`  
- `src/components/common/ProjectCard.tsx`  
- `src/components/domain/create/CreateForm.tsx`  
- `src/components/domain/home/HeroBanner.tsx`  
- `src/types/common/project.type.ts`  


---

## 기타 참고 사항
- 기존 단일 필드 기반 구조를 EN/KR 구분 구조로 리팩토링  
- 관련 페이지 전체에서 다국어 데이터 정상 출력 확인 완료  
---

## 작업 스크린샷

<img width="942" height="843" alt="image" src="https://github.com/user-attachments/assets/351c66ca-a375-446a-a9ca-6dac3e6a9666" />
