### PR TITLE
style: items-start 스타일 적용 및 간격 통일

### DIFF
--- a/src/components/domain/projects/AllProjectsTab.tsx
+++ b/src/components/domain/projects/AllProjectsTab.tsx
@@ -10,7 +10,7 @@ export default async function AllProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 md:items-start  justify-items-center lg:grid-cols-3 lg:gap-y-25">
           {datas.map((data) => (
             <ProjectCard key={data.id} data={data} currentTab="1" />
           ))}

--- a/src/components/domain/projects/PersonalProjectsTab.tsx
+++ b/src/components/domain/projects/PersonalProjectsTab.tsx
@@ -11,7 +11,7 @@ export default async function PersonalProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 md:items-start justify-items-center lg:grid-cols-3 lg:gap-y-25">
           {datas.map((data) => (
             <ProjectCard key={data.id} data={data} currentTab="3" />
           ))}

--- a/src/components/domain/projects/TeamProjectsTab.tsx
+++ b/src/components/domain/projects/TeamProjectsTab.tsx
@@ -11,7 +11,7 @@ export default async function TeamProjectsTab() {
           N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
         </div>
       ) : (
-        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 justify-items-center lg:grid-cols-3 lg:gap-y-25">
+        <div className="grid  grid-cols-1 gap-14 md:grid-cols-2 md:items-start justify-items-center lg:grid-cols-3 lg:gap-y-25">
           {datas.map((data) => (
             <ProjectCard key={data.id} data={data} currentTab="2" />
           ))}


### PR DESCRIPTION
## 작업 개요
- Projects 탭(All, Personal, Team)에 `items-start` 스타일 적용  
- 카드 간격을 통일하여 레이아웃 일관성 개선  

---

## 작업 상세 내용
- [x] AllProjectsTab 레이아웃 정렬 수정 (`items-start`)  
- [x] PersonalProjectsTab 레이아웃 정렬 수정 (`items-start`)  
- [x] TeamProjectsTab 레이아웃 정렬 수정 (`items-start`)  
- [x] 탭별 카드 간격 통일  

---

## 수정한 파일
- `src/components/domain/projects/AllProjectsTab.tsx`  
- `src/components/domain/projects/PersonalProjectsTab.tsx`  
- `src/components/domain/projects/TeamProjectsTab.tsx`  
