### PR TITLE
refactor: About 프로필 이미지 제거

### DIFF
--- a/src/components/domain/about/AboutHeadline.tsx
+++ b/src/components/domain/about/AboutHeadline.tsx
@@ -32,18 +32,18 @@ export default function AboutHeadline() {
     // 2. 텍스트 애니메이션 완료 후 Lottie 표시
     const lottieTimer = setTimeout(() => {
       setShowLottie(true);
+      setIntroDone(true);
     }, totalDuration + 500);
 
-    // 3. 텍스트 애니메이션 완료 후 프로필 이미지 표시
-    const profileTimer = setTimeout(() => {
-      setShowProfile(true);
-      setIntroDone(true);
-    }, totalDuration + 700);
+    // // 3. 텍스트 애니메이션 완료 후 프로필 이미지 표시
+    // const profileTimer = setTimeout(() => {
+    //   setShowProfile(true);
+    // }, totalDuration + 700);
 
     return () => {
       clearTimeout(textTimer);
       clearTimeout(lottieTimer);
-      clearTimeout(profileTimer);
+      // clearTimeout(profileTimer);
     };
   }, [totalDuration]);
 
@@ -155,7 +155,7 @@ export default function AboutHeadline() {
           />
         </div>
       </div>
-      {/* 프로필 이미지 (scrollY===0일 때만 보임) */}
+      {/* 프로필 이미지 (scrollY===0일 때만 보임)
       <div
         className={`absolute right-0 bottom-0 transition-opacity duration-700 ${
           showProfile ? "opacity-100" : "opacity-0"
@@ -168,7 +168,7 @@ export default function AboutHeadline() {
           className="sm:size-40 md:size-70 lg:size-90"
           unoptimized
         />
-      </div>
+      </div> */}
     </div>
   );
 }


### PR DESCRIPTION
## 작업 개요
- AboutHeadline 컴포넌트에서 사용하지 않는 프로필 이미지 섹션 제거
- 관련 상태 및 주석 처리된 코드 정리


---

## 작업 상세 내용
- [x] 불필요한 상태(`showProfile`) 및 주석 제거
- [x] 스크롤 이벤트 내 프로필 관련 조건문 제거

---

## 수정한 파일
- `src/components/domain/about/AboutHeadline.tsx`

---

## 기타 참고 사항
- 기능 동작에 영향 없음

