### PR TITLE
refactor: 홈 화면 프로젝트 섹션 구조 및 다국어 키 개편

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,8 @@
 {
   "HomePage": {
     "title": "M Y\u00A0\u00A0\u00A0L A T E S T\u00A0\u00A0\u00A0P R O J E C T\u00A0\u00A0\u00A02 0 2 5",
-    "appLink": "N E W E S T\u00A0\u00A0\u00A0P R O J E C T S",
+    "teamProjectLink": "T E A M\u00A0\u00A0\u00A0P R O J E C T S",
+    "personalProjectLink": "P E R S O N A L\u00A0\u00A0\u00A0P R O J E C T S",
     "more": "M\u00A0\u00A0O\u00A0\u00A0R\u00A0\u00A0\u00A0E",
     "ScoreSection": {
       "performance": "P E R F O R M A N C E",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,8 +1,9 @@
 {
   "HomePage": {
     "title": "2 0 2 5 년\u00A0\u00A0\u00A0나 의\u00A0\u00A0\u00A0최 신\u00A0\u00A0\u00A0작 업 물",
-    "appLink": "최 신\u00A0\u00A0\u00A0프 로 젝 트",
-    "more": "프 로 젝 트\u00A0\u00A0\u00A0더 보 기",
+    "teamProjectLink": "팀\u00A0\u00A0\u00A0프 로 젝 트",
+    "personalProjectLink": "개 인\u00A0\u00A0\u00A0프 로 젝 트",
+    "more": "전 체\u00A0\u00A0\u00A0프 로 젝 트",
     "ScoreSection": {
       "performance": "성 능",
       "seo": "검 색 엔 진 최 적 화",
@@ -18,7 +19,7 @@
   },
   "ProjectsPage": {
     "tabs": {
-      "all": "모 든\u00A0\u00A0\u00A0프 로 젝 트",
+      "all": "전 체\u00A0\u00A0\u00A0프 로 젝 트",
       "team": "팀\u00A0\u00A0\u00A0프 로 젝 트",
       "personal": "개 인\u00A0\u00A0\u00A0프 로 젝 트"
     },

--- a/src/api/readLatestProject.action.ts
+++ b/src/api/readLatestProject.action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { database } from "@/firebase/firebaseConfig";
+import { ref, query, orderByChild, limitToLast, get } from "firebase/database";
+import { ProjectPayload } from "@/types";
+
+export async function readLatestProject(): Promise<ProjectPayload | null> {
+  try {
+    const projectsRef = ref(database, "projects");
+    // createdAt 기준으로 정렬하고 마지막 1개만 가져오기
+    const q = query(projectsRef, orderByChild("createdAt"), limitToLast(1));
+
+    const snapshot = await get(q);
+
+    if (!snapshot.exists()) {
+      return null;
+    }
+
+    const data = snapshot.val();
+    const projects = Object.values(data) as ProjectPayload[];
+
+    return projects[0];
+  } catch (err) {
+    console.error("readLatestProject error:", err);
+    return null;
+  }
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import { readAllProjects } from "@/api/readAllProjects.action";
 import AppLink from "@/components/common/AppLink";
 import ProjectCard from "@/components/common/ProjectCard";
 import HeroBanner from "@/components/domain/home/HeroBanner";
@@ -6,26 +5,33 @@ import Image from "next/image";
 import blog from "@/assets/images/blog.png";
 import { readDeployProjectUrl } from "@/api/raedDeployProjectUrl.action";
 import { getTranslations } from "next-intl/server";
+import { readTeamProjects } from "@/api/readTeamProjects.action";
+import { readPersonalProjects } from "@/api/readPersonalProjects.action";
+import { readLatestProject } from "@/api/readLatestProject.action";
 
 export default async function HomePage() {
   const t = await getTranslations("HomePage");
-  const [datas, deployUrl] = await Promise.all([
-    readAllProjects(),
-    readDeployProjectUrl(),
-  ]);
+
+  const [latestProject, teamProjects, personalProjects, deployUrl] =
+    await Promise.all([
+      readLatestProject(),
+      readTeamProjects(),
+      readPersonalProjects(),
+      readDeployProjectUrl(),
+    ]);
 
   return (
     <div>
       <h1 className="text-center mb-3 md:mb-4   text-14-semibold md:text-16-semibold">
         {t("title")}
       </h1>
-      <HeroBanner data={datas[0]} />
+      {latestProject && <HeroBanner data={latestProject} />}
       <div>
-        <div className="relative z-10 py-14">
-          <AppLink text={t("appLink")} href="/projects/" />
+        <div className="relative z-10 py-14  md:py-16">
+          <AppLink text={t("teamProjectLink")} href="/projects/?tab=2" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-items-center gap-14">
-          {datas.slice(1).map((data, idx) => (
+          {teamProjects.map((data, idx) => (
             <div
               key={data.id}
               className={`
@@ -33,11 +39,27 @@ export default async function HomePage() {
         ${idx >= 3 ? "lg:hidden" : ""} /* lg 이상에서는 3개까지만 */
       `}
             >
-              <ProjectCard data={data} currentTab="1" />
+              <ProjectCard data={data} currentTab="2" />
             </div>
           ))}
         </div>
-        <div className="relative z-10 pt-14 md:py-14 flex justify-center">
+        <div className="relative z-10 py-14 md:py-16">
+          <AppLink text={t("personalProjectLink")} href="/projects/?tab=3" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-items-center gap-14">
+          {personalProjects.map((data, idx) => (
+            <div
+              key={data.id}
+              className={`
+        ${idx >= 4 ? "hidden" : ""}   /* 기본적으로 4개까지만 */
+        ${idx >= 3 ? "lg:hidden" : ""} /* lg 이상에서는 3개까지만 */
+      `}
+            >
+              <ProjectCard data={data} currentTab="3" />
+            </div>
+          ))}
+        </div>
+        <div className="relative z-10 pt-14 md:py-16 flex justify-center">
           <AppLink text={t("more")} href="/projects/" />
         </div>
       </div>

--- a/src/components/common/Notification.tsx
+++ b/src/components/common/Notification.tsx
@@ -28,10 +28,8 @@ export default function Notification({
       className={`
             flex items-center gap-4
             ${success ? "bg-black-100" : "bg-red-500"}
-            max-w-92 min-h-16 w-9/10 fixed bottom-5 
-            left-1/2 -translate-x-1/2
-            md:left-auto md:translate-x-0
-            md:bottom-9 md:right-5
+            max-w-97 min-h-16 w-9/10 fixed bottom-5 right-5 
+            md:bottom-9 
             px-4 py-3 rounded-sm shadow text-white z-40
           `}
     >

--- a/src/components/domain/about/AboutHeadline.tsx
+++ b/src/components/domain/about/AboutHeadline.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from "react";
 import Lottie from "lottie-react";
 import scrollAnimation from "@/assets/lotties/scroll.json";
 import aboutIcon from "@/assets/images/about.svg";
-import profileImage from "@/assets/images/profile.png";
 import Image from "next/image";
 import { toggleBodyScroll } from "@/utils";
 import { useTranslations } from "next-intl";

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -26,8 +26,8 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   const showNotification = (message: string, success: boolean) => {
     setNotification({ message, success });
 
-    // 5초 뒤 자동 닫기
-    setTimeout(() => setNotification(null), 5000);
+    // 7초 뒤 자동 닫기
+    setTimeout(() => setNotification(null), 7000);
   };
 
   return (


### PR DESCRIPTION
## 작업 개요
- 홈 화면 프로젝트 섹션 구조 개편
- 최신/팀/개인 프로젝트 구분 렌더링
- 다국어 키(appLink 제거 → teamProjectLink, personalProjectLink 추가) 반영
- Notification 위치 및 자동 닫힘 시간 수정
---

## 작업 상세 내용
- [x] 최신 프로젝트 HeroBanner 렌더링 (readLatestProject)
- [x] 팀 프로젝트, 개인 프로젝트 분리 및 카드 출력 제한 로직 적용
- [x] 다국어 JSON(en/ko) 수정
- [x] Notification 위치를 중앙 → 우측 고정으로 변경
- [x] Notification 자동 닫힘 시간 5초 → 7초로 조정

---

## 수정한 파일
- `messages/en.json`
- `messages/ko.json`
- `src/app/[locale]/page.tsx`
- `src/components/common/Notification.tsx`
- `src/context/NotificationContext.tsx`


---

## 기타 참고 사항
- 이번 PR은 홈 화면 구조 개편과 다국어 반영에 집중


