### PR TITLE
feat: About 및 Project 상세 페이지 SEO 메타데이터 다국어 최적화 적용

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,40 @@
 {
+  "HomeMetaData": {
+    "title": "Hong Sunghoon - Web Developer Portfolio",
+    "description": "A personal portfolio website designed to introduce myself and showcase my projects and experiences at a glance. It organizes my background, skills, and work to help visitors easily understand my capabilities.",
+    "openGraph": {
+      "title": "Hong Sunghoon - Web Developer Portfolio",
+      "description": "Personal portfolio website showcasing my profile, projects, and experiences in one place.",
+      "url": "https://madebyhshfolio.site/en",
+      "siteName": "Hong Sunghoon Portfolio",
+      "imageAlt": "Site Preview Image"
+    },
+    "twitter": {
+      "title": "Hong Sunghoon - Web Developer Portfolio",
+      "description": "Personal portfolio website showcasing my profile, projects, and experiences in one place.",
+      "imageAlt": "Site Preview Image"
+    }
+  },
+  "AboutMetaData": {
+    "title": "About - Hong Sunghoon Portfolio",
+    "description": "Learn more about Hong Sunghoon: background, experiences, and core beliefs as a web developer.",
+    "openGraph": {
+      "title": "About - Hong Sunghoon Portfolio",
+      "description": "Discover Hong Sunghoon’s journey, skills, and philosophy as a web developer.",
+      "url": "https://madebyhshfolio.site/en/about",
+      "siteName": "Hong Sunghoon Portfolio",
+      "imageAlt": "About Page Preview"
+    },
+    "twitter": {
+      "title": "About - Hong Sunghoon Portfolio",
+      "description": "Discover Hong Sunghoon’s journey, skills, and philosophy as a web developer.",
+      "imageAlt": "About Page Preview"
+    }
+  },
+  "ProjectDetailMetaData": {
+    "siteName": "Hong Sunghoon Portfolio",
+    "imageAlt": "Project Preview Image"
+  },
   "HomePage": {
     "title": "M Y\u00A0\u00A0\u00A0L A T E S T\u00A0\u00A0\u00A0P R O J E C T\u00A0\u00A0\u00A02 0 2 5",
     "teamProjectLink": "T E A M\u00A0\u00A0\u00A0P R O J E C T S",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,40 @@
 {
+  "HomeMetaData": {
+    "title": "홍성훈 - 디지털 포트폴리오 웹사이트",
+    "description": "개발자 본인을 소개하고 프로젝트와 경험을 한눈에 보여주는 개인 포트폴리오 웹사이트입니다. 배경, 기술, 작업물을 정리하여 방문자가 내 역량을 쉽게 이해할 수 있도록 구성했습니다.",
+    "openGraph": {
+      "title": "홍성훈 - 디지털 포트폴리오 웹사이트",
+      "description": "프로필, 프로젝트, 경험을 한 곳에 모아 소개하는 개인 포트폴리오 웹사이트",
+      "url": "https://madebyhshfolio.site/ko",
+      "siteName": "홍성훈 포트폴리오",
+      "imageAlt": "사이트 미리보기 이미지"
+    },
+    "twitter": {
+      "title": "홍성훈 - 디지털 포트폴리오 웹사이트",
+      "description": "프로필, 프로젝트, 경험을 한 곳에 모아 소개하는 개인 포트폴리오 웹사이트",
+      "imageAlt": "사이트 미리보기 이미지"
+    }
+  },
+  "AboutMetaData": {
+    "title": "소개 - 홍성훈 포트폴리오",
+    "description": "웹 개발자로서 홍성훈의 배경, 경험, 핵심 가치를 확인할 수 있습니다.",
+    "openGraph": {
+      "title": "소개 - 홍성훈 포트폴리오",
+      "description": "홍성훈의 개발 여정, 기술 스택, 가치관을 소개합니다.",
+      "url": "https://madebyhshfolio.site/ko/about",
+      "siteName": "홍성훈 포트폴리오",
+      "imageAlt": "소개 페이지 미리보기 이미지"
+    },
+    "twitter": {
+      "title": "소개 - 홍성훈 포트폴리오",
+      "description": "홍성훈의 개발 여정, 기술 스택, 가치관을 소개합니다.",
+      "imageAlt": "소개 페이지 미리보기 이미지"
+    }
+  },
+  "ProjectDetailMetaData": {
+    "siteName": "홍성훈 포트폴리오",
+    "imageAlt": "프로젝트 미리보기 이미지"
+  },
   "HomePage": {
     "title": "2 0 2 5 년\u00A0\u00A0\u00A0나 의\u00A0\u00A0\u00A0최 신\u00A0\u00A0\u00A0작 업 물",
     "teamProjectLink": "팀\u00A0\u00A0\u00A0프 로 젝 트",

--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("AboutMetaData");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    openGraph: {
+      title: t("openGraph.title"),
+      description: t("openGraph.description"),
+      url: t("openGraph.url"),
+      siteName: t("openGraph.siteName"),
+      images: [
+        {
+          url: "/seo.png",
+          width: 1200,
+          height: 630,
+          alt: t("openGraph.imageAlt"),
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("twitter.title"),
+      description: t("twitter.description"),
+      images: ["/seo.png"],
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -5,6 +5,9 @@ import AboutInterview from "@/components/domain/about/AboutInterview";
 import AboutMyExperience from "@/components/domain/about/AboutMyExperience";
 import AboutTechStack from "@/components/domain/about/AboutTechStack";
 
+
+
+
 export default function AboutPage() {
   return (
     <div className="pb-10 sm:pb-20">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,7 +9,7 @@ import { UserProvider } from "@/context/UserContext";
 import { NotificationProvider } from "@/context/NotificationContext";
 import { routing } from "@/i18n/routing";
 import { notFound } from "next/navigation";
-import { getMessages } from "next-intl/server";
+import { getMessages, getTranslations } from "next-intl/server";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 
 const poppins = Poppins({
@@ -22,37 +22,36 @@ const spaceGrotesk = Space_Grotesk({
   weight: ["400", "500", "600", "700"],
 });
 
-export const metadata: Metadata = {
-  title: "Hong Sunghoon - Web Developer Portfolio",
-  description:
-    "A personal portfolio website designed to introduce myself and showcase my projects and experiences at a glance. It organizes my background, skills, and work to help visitors easily understand my capabilities.",
-  icons: {
-    icon: "/favicon.ico",
-  },
-  openGraph: {
-    title: "Hong Sunghoon - Web Developer Portfolio",
-    description:
-      "Personal portfolio website showcasing my profile, projects, and experiences in one place.",
-    url: "https://madebyhshfolio.site/",
-    siteName: "Hong Sunghoon Portfolio",
-    images: [
-      {
-        url: "/seo.png",
-        width: 1200,
-        height: 630,
-        alt: "Site Preview Image",
-      },
-    ],
-    type: "website",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Hong Sunghoon - Web Developer Portfolio",
-    description:
-      "Personal portfolio website showcasing my profile, projects, and experiences in one place.",
-    images: ["/seo.png"],
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("HomeMetaData");
+  return {
+    title: t("title"),
+    description: t("description"),
+    icons: {
+      icon: "/favicon.ico",
+    },
+    openGraph: {
+      title: t("openGraph.title"),
+      description: t("openGraph.description"),
+      url: t("openGraph.url"),
+      siteName: t("openGraph.siteName"),
+      images: [
+        {
+          url: "/seo.png",
+          width: 1200,
+          height: 630,
+          alt: t("openGraph.imageAlt"),
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("twitter.title"),
+      description: t("twitter.description"),
+      images: ["/seo.png"],
+    },
+  };
+}
 
 export default async function RootLayout({
   children,

--- a/src/app/[locale]/projects/[id]/page.tsx
+++ b/src/app/[locale]/projects/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { readAdjacentProjects } from "@/api/readAdjacentProjects.action";
 import { readProjectById } from "@/api/readProject.action";
 import Shortcut from "@/components/domain/projects/Shortcut";
+import { Metadata } from "next";
 import { getTranslations, getLocale } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
@@ -12,6 +13,56 @@ const positionOrder: Record<string, number> = {
   "Sub Leader": 1,
   "Team Member": 2,
 };
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string; locale: string }>;
+  searchParams: Promise<{ tab?: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const { tab } = await searchParams;
+  const locale = (await getLocale()) as "en" | "ko";
+  const t = await getTranslations("ProjectDetailMetaData");
+
+  const data = await readProjectById(id);
+
+  if (!data) notFound();
+
+  const baseUrl = "https://madebyhshfolio.site";
+  const currentUrl = `${baseUrl}/${locale}/projects/${id}${
+    tab ? `?tab=${tab}` : "?tab=1"
+  }`;
+
+  return {
+    title: `${data.title[locale]} - ${data.tagline[locale]}`,
+    description: `${data.description[locale]}`,
+    icons: {
+      icon: "/favicon.ico",
+    },
+    openGraph: {
+      title: `${data.title[locale]} - ${data.tagline[locale]}`,
+      description: `${data.description[locale]}`,
+      url: currentUrl,
+      siteName: t("siteName"),
+      images: [
+        {
+          url: `${data.projectImageUrl}`,
+          width: 1200,
+          height: 630,
+          alt: t("imageAlt"),
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${data.title[locale]} - ${data.tagline[locale]}`,
+      description: `${data.description[locale]}`,
+      images: `${data.projectImageUrl}`,
+    },
+  };
+}
 
 export default async function ProjectDetailPage({
   params,


### PR DESCRIPTION
## 작업 개요
- About 및 Project 상세 페이지에 SEO 메타데이터 다국어(i18n) 적용
- OpenGraph, Twitter 카드 메타데이터 개선 및 다국어 description 반영

---

## 작업 상세 내용
- [x] `messages/en.json`, `messages/ko.json`에 `AboutMetaData`, `ProjectDetailMetaData` 추가  
- [x] About 페이지 `layout.tsx` 생성 및 정적 SEO 메타데이터 적용  
- [x] Project 상세 페이지 `generateMetadata` 개선 (title/description/og:image 다국어 적용)  
- [x] `openGraph.url`, `canonical`을 locale/id 기반 동적 URL로 생성  

---

## 수정한 파일
- `messages/en.json`  
- `messages/ko.json`  
- `src/app/[locale]/about/page.tsx`  
- `src/app/[locale]/layout.tsx`  
- `src/app/[locale]/projects/[id]/page.tsx`  

## 새로 작성한 파일
- `src/app/[locale]/about/layout.tsx`  
---

## 기타 참고 사항

- SEO 이미지(`seo.png`)는 기존 리소스 사용, 추후 필요 시 페이지별 맞춤 이미지 교체 가능  


