### PR TITLE
fix: ProjectCard i18n Link 적용으로 locale 경로 누락 버그 수정

### DIFF
--- a/src/components/common/ProjectCard.tsx
+++ b/src/components/common/ProjectCard.tsx
@@ -1,7 +1,7 @@
 import { ProjectPayload } from "@/types";
 import { getTranslations, getLocale } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { FaArrowRightLong } from "react-icons/fa6";
 
 export default async function ProjectCard({


### PR DESCRIPTION
## 작업 개요

- ProjectCard i18n Link 적용으로 locale 경로 누락 버그 수정 

---

## 작업 상세 내용

- [x] 상세페이지 누르면 en -> en이 아닌 en -> ko로 갑자기 변경됨. 이를 해결하기 위해 i18n Link  적용

---

## 수정한 파일

- `src/components/common/ProjectCard.tsx`

