### PR TITLE
style: HeroBanner tagline 중앙 정렬 및 전역 word-break 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -337,6 +337,7 @@ html,
 body {
   background-color: var(--color-bg-100);
   color: var(--color-black-100);
+  word-break: break-keep;
 }
 
 button,

--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -42,7 +42,7 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
               <h3 className="text-18-bold mb-2 lg:text-20-bold">
                 {data.title[locale]}
               </h3>
-              <h4 className="text-14-regular lg:text-16-regular">
+              <h4 className="text-center text-14-regular lg:text-16-regular">
                 {data.tagline[locale]}
               </h4>
               <span className="text-14-regular lg:text-16-regular">-</span>


### PR DESCRIPTION
## 작업 개요

- HeroBanner tagline 텍스트 중앙 정렬
- 전역 word-break 정책을 `break-keep`으로 수정

---

## 작업 상세 내용
- `globals.css`
  - `word-break: break-keep;` 추가 → 한글 단어 중간 줄바꿈 방지
- `HeroBanner.tsx`
  - tagline 텍스트에 `text-center` 클래스 추가 → 다국어 문구 중앙 정렬

---

## 수정한 파일

- `src/app/globals.css`
- `src/components/domain/home/HeroBanner.tsx`

