### PR TITLE
style: 오버레이 투명도 조정 및 UI 개선

### DIFF
--- a/src/app/[locale]/projects/[id]/page.tsx
+++ b/src/app/[locale]/projects/[id]/page.tsx
@@ -157,7 +157,7 @@ export default async function ProjectDetailPage({
             />
 
             {/* 오버레이 */}
-            <div className="text-gray-200 absolute inset-0 bg-black/70 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100">
+            <div className="text-gray-200 absolute inset-0 bg-black/50 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100">
               <div className="absolute right-5 top-5 md:top-7 md:right-7">
                 <Image
                   src={linkIcon}

--- a/src/components/common/ProjectCard.tsx
+++ b/src/components/common/ProjectCard.tsx
@@ -29,7 +29,7 @@ export default async function ProjectCard({
         />
         <div
           className="
-            absolute inset-0 bg-black/70 opacity-0
+            absolute inset-0 bg-black/50 opacity-0
             transition-opacity duration-300
             group-hover:opacity-100 text-gray-100
             flex justify-center items-center

--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -30,7 +30,7 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
           />
 
           {/* 오버레이 */}
-          <div className="absolute inset-0 bg-black/10 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100" />
+          <div className="absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100" />
         </Link>
         <div className="md:flex md:w-180  md:mx-auto py-7 md:py-10 justify-between lg:w-230 ">
           <div className="mb-5 md:mb-0 md:flex md:items-center md:gap-5 ">


### PR DESCRIPTION
## 작업 개요

- 프로젝트 카드, 디테일 페이지, 히어로 배너의 오버레이 투명도 조정
- 사용자 hover 시 시각적 일관성 강화

---

## 작업 상세 내용

- [x] ProjectDetailPage: 오버레이 투명도 `70% → 50%` 변경
- [x] ProjectCard: 오버레이 투명도 `70% → 50%` 변경
- [x] HeroBanner: 오버레이 투명도 `10% → 20%` 변경

---

## 수정한 파일
- `src/app/[locale]/projects/[id]/page.tsx`
- `src/components/common/ProjectCard.tsx`
- `src/components/domain/home/HeroBanner.tsx`
