### PR TITLE
feat: 프로젝트 카드 및 상세 페이지에 다중 이미지 지원 추가

### DIFF
--- a/src/api/createProject.action.ts
+++ b/src/api/createProject.action.ts
@@ -44,6 +44,14 @@ export async function createProject(
       en: String(formData.get("category_en") || "").trim(),
       ko: String(formData.get("category_ko") || "").trim(),
     };
+    // Project Image URLs (쉼표 구분)
+    const projectImageUrlsRaw = String(
+      formData.get("projectImageUrls") || ""
+    ).trim();
+    const projectImageUrls = projectImageUrlsRaw
+      .split(",")
+      .map((url) => url.trim())
+      .filter((url) => url.length > 0);
 
     // 단일 필드
     const projectUrl = String(formData.get("projectUrl") || "").trim();
@@ -104,7 +112,7 @@ export async function createProject(
       description, // { en, ko }
       category, // { en, ko }
       projectUrl,
-      projectImageUrl,
+      projectImageUrls,
       projectGitHubUrl,
       performanceScore,
       accessibilityScore,

--- a/src/app/[locale]/projects/[id]/page.tsx
+++ b/src/app/[locale]/projects/[id]/page.tsx
@@ -7,8 +7,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MdInsights } from "react-icons/md";
-import linkIcon from "@/assets/images/link.svg";
-import { FaArrowRightLong } from "react-icons/fa6";
 
 const positionOrder: Record<string, number> = {
   "Team Leader": 0,
@@ -50,7 +48,7 @@ export async function generateMetadata({
       siteName: t("siteName"),
       images: [
         {
-          url: `${data.projectImageUrl}`,
+          url: `${data.projectImageUrls[0]}`,
           width: 1200,
           height: 630,
           alt: t("imageAlt"),
@@ -61,7 +59,7 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: `${data.title[locale]} - ${data.tagline[locale]}`,
       description: `${data.description[locale]}`,
-      images: `${data.projectImageUrl}`,
+      images: `${data.projectImageUrls[0]}`,
     },
   };
 }
@@ -92,7 +90,7 @@ export default async function ProjectDetailPage({
             className="group block relative overflow-hidden"
           >
             <Image
-              src={adjacent.prev.projectImageUrl}
+              src={adjacent.prev.projectImageUrls[0]}
               alt="projectImage"
               width={160}
               height={0}
@@ -123,7 +121,7 @@ export default async function ProjectDetailPage({
             className="group block relative overflow-hidden"
           >
             <Image
-              src={adjacent.next.projectImageUrl}
+              src={adjacent.next.projectImageUrls[0]}
               alt="projectImage"
               width={160}
               height={0}
@@ -167,35 +165,17 @@ export default async function ProjectDetailPage({
             target="_blank"
             className="relative inline-block w-fit group "
           >
-            <Image
-              src={data.projectImageUrl}
-              alt="projectImageUrl"
-              width={740}
-              height={0}
-              className="block cursor-pointer"
-              unoptimized
-            />
-
-            {/* 오버레이
-            <div className="text-gray-200 absolute inset-0 bg-black/50 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100">
-              <div className="absolute right-5 top-5 md:top-7 md:right-7">
-                <Image
-                  src={linkIcon}
-                  alt="link"
-                  width={18}
-                  className="md:size-5"
-                />
-              </div>
-              <div className="absolute left-1/2 top-1/2 -translate-1/2">
-                <div className=" flex items-center gap-2 text-16-semibold md:text-18-semibold">
-                  <h4>{t("labels.link")}</h4>
-                  <FaArrowRightLong />
-                </div>
-              </div>
-              <div className="absolute left-5 top-5 md:top-7 md:left-7 text-12-medium md:text-14-medium">
-                {t("labels.updatedText")}
-              </div>
-            </div> */}
+            {data.projectImageUrls.map((projectImg, index) => (
+              <Image
+                key={index}
+                src={projectImg}
+                alt="projectImageUrl"
+                width={740}
+                height={0}
+                className="block cursor-pointer"
+                unoptimized
+              />
+            ))}
           </Link>
         </div>
         <div className="flex flex-col gap-7 md:gap-10 px-7 mb-10 md:mb-15 md:flex-row">

--- a/src/components/common/ProjectCard.tsx
+++ b/src/components/common/ProjectCard.tsx
@@ -23,7 +23,7 @@ export default function ProjectCard({
     >
       <div className="relative w-fit">
         <Image
-          src={data.projectImageUrl}
+          src={data.projectImageUrls[0]}
           alt="projectImageUrl"
           width={370}
           height={0}
@@ -53,7 +53,7 @@ export default function ProjectCard({
             </div>
             <div className="absolute left-1/2 top-1/2 -translate-1/2">
               <div className=" flex items-center gap-2 text-16-semibold">
-                <h4>{t("viewProject")}</h4>
+                <h4 className="text-nowrap">{t("viewProject")}</h4>
                 <FaArrowRightLong />
               </div>
             </div>

--- a/src/components/domain/create/CreateForm.tsx
+++ b/src/components/domain/create/CreateForm.tsx
@@ -216,15 +216,15 @@ export default function CreateProjectForm() {
           </label>
 
           <label className="block mt-4">
-            <span>PROJECT IMAGE URL</span>
+            <span>PROJECT IMAGE URLS</span>
             <input
-              name="projectImageUrl"
-              type="url"
+              name="projectImageUrls"
+              type="text"
               required
               className="w-full border border-line-100 rounded px-3 py-2"
+              placeholder="https://a.png, https://b.png, https://c.png"
             />
           </label>
-
           <label className="block mt-4">
             <span>PROJECT GITHUB URL</span>
             <input

--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -21,7 +21,7 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
           className="relative inline-block w-fit md:block md:mx-auto group shadow-image"
         >
           <Image
-            src={data.projectImageUrl}
+            src={data.projectImageUrls[0]}
             alt="projectImageUrl"
             width={765}
             height={0}

--- a/src/types/common/project.type.ts
+++ b/src/types/common/project.type.ts
@@ -17,7 +17,7 @@ export interface ProjectPayload {
   description: { en: string; ko: string };
   category: { en: string; ko: string };
   projectUrl: string;
-  projectImageUrl: string;
+  projectImageUrls: string[];
   projectGitHubUrl: string;
   performanceScore: number;
   accessibilityScore: number;


### PR DESCRIPTION
## 작업 개요
- 프로젝트 카드, 상세, 배너에서 단일 이미지를 다중 이미지 배열(`projectImageUrls`)로 변경
- 사용자들이 프로젝트의 다양한 화면을 확인할 수 있도록 개선
---

## 작업 상세 내용
- [x] `createProject.action.ts`에서 `projectImageUrls` 처리 로직 추가 (쉼표 구분 문자열 → 배열 변환)
- [x] `project.type.ts` 타입 수정 (`projectImageUrl` → `projectImageUrls: string[]`)
- [x] ProjectCard / ProjectDetailPage / HeroBanner 컴포넌트에서 첫 번째 이미지를 기본 표시
- [x] ProjectDetailPage에 다중 이미지 순회 렌더링 적용
- [x] CreateForm 입력 필드를 `projectImageUrls`로 변경 및 placeholder 추가

---

## 수정한 파일
- `src/api/createProject.action.ts`
- `src/app/[locale]/projects/[id]/page.tsx`
- `src/components/common/ProjectCard.tsx`
- `src/components/domain/create/CreateForm.tsx`
- `src/components/domain/home/HeroBanner.tsx`
- `src/types/common/project.type.ts`


---

## 기타 참고 사항

- 새 프로젝트 생성 시 `PROJECT IMAGE URLS` 입력 칸에 여러 개의 URL을 쉼표로 구분하여 입력

---

## 작업 스크린샷

<img width="1907" height="2090" alt="image" src="https://github.com/user-attachments/assets/10143d7c-83c8-4bf4-abad-a7cefdb896d3" />
