### PR TITLE
feat: HeroBannerWide 컴포넌트 추가 및 HeroBanner hover 툴팁 애니메이션 구현

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import { getTranslations } from "next-intl/server";
 import { readTeamProjects } from "@/api/readTeamProjects.action";
 import { readPersonalProjects } from "@/api/readPersonalProjects.action";
 import { readLatestProject } from "@/api/readLatestProject.action";
+import HeroBannerWide from "@/components/domain/home/HeroBannerWide";
 
 export default async function HomePage() {
   const t = await getTranslations("HomePage");
@@ -22,10 +23,22 @@ export default async function HomePage() {
 
   return (
     <div>
-      <h1 className="text-center mb-3 md:mb-4   text-14-semibold md:text-16-semibold">
+      <h1 className="lg:hidden text-center mb-3 md:mb-4   text-14-semibold md:text-16-semibold">
         {t("title")}
       </h1>
-      {latestProject && <HeroBanner data={latestProject} />}
+      {latestProject && (
+        <>
+          {/* 모바일용 */}
+          <div className="block lg:hidden">
+            <HeroBanner data={latestProject} />
+          </div>
+
+          {/* 데스크톱용 */}
+          <div className="hidden lg:block">
+            <HeroBannerWide data={latestProject} />
+          </div>
+        </>
+      )}
       <div>
         <div className="relative z-10 py-14  md:py-16">
           <AppLink text={t("teamProjectLink")} href="/projects/?tab=2" />

--- a/src/components/domain/home/HeroBanner.tsx
+++ b/src/components/domain/home/HeroBanner.tsx
@@ -1,14 +1,19 @@
+"use client";
+
 import { ProjectPayload } from "@/types";
 import Image from "next/image";
 import { Link } from "@/i18n/routing";
 import badge from "@/assets/images/badge.svg";
 import { MdInsights } from "react-icons/md";
-import { getTranslations, getLocale } from "next-intl/server";
+import { useLocale, useTranslations } from "next-intl";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 
-export default async function HeroBanner({ data }: { data: ProjectPayload }) {
-  const t = await getTranslations("HomePage");
-  const locale = (await getLocale()) as "en" | "ko";
-  // participants가 배열이면 그대로, 객체면 Object.values로 배열화, 없으면 빈 배열
+export default function HeroBanner({ data }: { data: ProjectPayload }) {
+  const t = useTranslations("HomePage");
+  const locale = useLocale() as "en" | "ko";
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
   const participants = Array.isArray(data.participants)
     ? data.participants
     : Object.values(data.participants || {});
@@ -77,42 +82,59 @@ export default async function HeroBanner({ data }: { data: ProjectPayload }) {
                       alt={`${participant.name}`}
                       width={40}
                       height={40}
+                      onMouseEnter={() => setHoveredId(participant.id)}
+                      onMouseLeave={() => setHoveredId(null)}
                     />
                   </a>
 
                   {/* 툴팁 */}
-                  <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
-                    <div className="flex flex-col gap-1.5 items-center bg-black-100 text-white  text-14-regular  shadow px-3 py-2 rounded-lg  whitespace-nowrap">
-                      {participant.name}
-                      <span className="text-12-regular">
-                        {participant.role}
-                      </span>
-                      {/* 화살표 */}
-                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-black-100"></div>
-                    </div>
-                  </div>
+                  <AnimatePresence>
+                    {hoveredId === participant.id && (
+                      <motion.div
+                        initial={{ opacity: 0, y: -8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -8 }}
+                        transition={{ duration: 0.2, ease: "easeOut" }}
+                        className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50"
+                      >
+                        <div className="relative flex flex-col gap-1.5 items-center bg-black-100 text-white text-14-regular shadow px-3 py-2 rounded-lg whitespace-nowrap">
+                          {participant.name}
+                          <span className="text-12-regular">
+                            {participant.role}
+                          </span>
+                          {/* 화살표 */}
+                          <div className="absolute -bottom-1 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-black-100"></div>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
                 </>
               )}
             </div>
           ))}
         </div>
-        <ul className="pt-6 md:pt-8 grid grid-cols-2 md:grid-cols-4 max-w-191.25 md:mx-auto  gap-y-6 [&_li]:flex  [&_li]:gap-1 [&_li]:flex-col [&_li]:justify-center  [&_li]:items-center [&_li>h4]:text-14-medium [&_li>span]:text-14-semibold">
+        <ul className="[&_div]:flex [&_div]:justify-center [&_div]:items-center [&_div]:size-12 [&_div]:rounded-full [&_div]:border-3 [&_div]:border-black pt-6 md:pt-8 grid grid-cols-2 md:grid-cols-4 max-w-191.25 md:mx-auto  gap-y-6 [&_li]:flex  [&_li]:gap-1.5 [&_li]:flex-col [&_li]:justify-center  [&_li]:items-center [&_li>h4]:text-14-medium [&_li>span]:text-14-semibold">
           <li>
-            <MdInsights size={40} />
+            <div>
+              <MdInsights size={28} />
+            </div>
             <h4>{t("ScoreSection.performance")}</h4>
             <span>{data.performanceScore}/100</span>
           </li>
-          <li className="!gap-0">
-            <MdInsights size={40} />
+          <li>
+            <div>
+              <MdInsights size={28} />
+            </div>
             <h4>{t("ScoreSection.seo")}</h4>
             <span>{data.seoScore}/100</span>
           </li>
           <li>
-            <MdInsights size={40} />
+            <div>
+              <MdInsights size={28} />
+            </div>
             <h4>{t("ScoreSection.accessibility")}</h4>
             <span>{data.accessibilityScore}/100</span>
           </li>
-
           <li>
             <p className="text-20-bold">{data.overallScore}/100</p>
             <h4>{t("ScoreSection.overall")}</h4>

--- a/src/components/domain/home/HeroBannerWide.tsx
+++ b/src/components/domain/home/HeroBannerWide.tsx
@@ -1,0 +1,143 @@
+"use client";
+import { ProjectPayload } from "@/types";
+import { useLocale, useTranslations } from "next-intl";
+import Image from "next/image";
+import Link from "next/link";
+import badge from "@/assets/images/badge.svg";
+import { MdInsights } from "react-icons/md";
+import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
+
+export default function HeroBannerWide({ data }: { data: ProjectPayload }) {
+  const t = useTranslations("HomePage");
+  const locale = useLocale() as "en" | "ko";
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const participants = Array.isArray(data.participants)
+    ? data.participants
+    : Object.values(data.participants || {});
+
+  return (
+    <div className="z-0 pl-25 relative h-168.75">
+      <h1 className="mb-4 text-16-semibold">{t("title")}</h1>
+      <Link
+        href={`/projects/${data.id}`}
+        className="z-10 relative inline-block w-fit group shadow-image"
+      >
+        <Image
+          src={data.projectImageUrls[0]}
+          alt="projectImageUrl"
+          width={740}
+          height={0}
+          className="block cursor-pointer"
+          unoptimized
+        />
+
+        {/* 오버레이 */}
+        <div className=" absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100" />
+      </Link>
+
+      <div className="absolute top-10 right-5 w-75">
+        <Image
+          src={badge}
+          alt="badge"
+          width={120}
+          className="!hidden md:!block ml-3 mb-6"
+        />
+        <div className="flex flex-col gap-0.5">
+          <h3 className="text-18-bold">{data.title[locale]}</h3>
+          <h4 className="text-14-regular">{data.tagline[locale]}</h4>
+          <span className="text-16-regular">-</span>
+          <h5 className="text-14-regular"> {data.platform[locale]}</h5>
+        </div>
+      </div>
+
+      <div className="bg-bg-300 max-w-215 w-full absolute h-90 right-0 bottom-0">
+        <div className="relative h-5/10 px-4 pt-7">
+          <div className="absolute w-3/10 right-15 h-full">
+            <p className="">
+              <em className="text-14-regular line-clamp-4 leading-5">
+                {data.description[locale]}
+              </em>
+            </p>
+            <div className="pt-6 flex">
+              {participants.map((participant) => (
+                <div
+                  key={participant.id}
+                  className="flex  relative group w-fit"
+                >
+                  {participant.imageUrl && (
+                    <>
+                      <a href={participant.githubUrl} target="_blank">
+                        <Image
+                          src={participant.imageUrl}
+                          alt={`${participant.name}`}
+                          width={40}
+                          height={40}
+                          onMouseEnter={() => setHoveredId(participant.id)}
+                          onMouseLeave={() => setHoveredId(null)}
+                        />
+                      </a>
+
+                      {/* 툴팁 */}
+                      <AnimatePresence>
+                        {hoveredId === participant.id && (
+                          <motion.div
+                            initial={{ opacity: 0, y: -8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -8 }}
+                            transition={{ duration: 0.2, ease: "easeOut" }}
+                            className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50"
+                          >
+                            <div className="relative flex flex-col gap-1.5 items-center bg-black-100 text-white text-14-regular shadow px-3 py-2 rounded-lg whitespace-nowrap">
+                              {participant.name}
+                              <span className="text-12-regular">
+                                {participant.role}
+                              </span>
+                              {/* 화살표 */}
+                              <div className="absolute -bottom-1 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-black-100"></div>
+                            </div>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="h-5/10 p-4">
+          <ul className="[&_div]:flex [&_div]:justify-center [&_div]:items-center [&_div]:size-12 [&_div]:rounded-full [&_div]:border-3 [&_div]:border-black pt-6 md:pt-8 grid grid-cols-2 md:grid-cols-4 max-w-191.25 md:mx-auto  gap-y-6 [&_li]:flex  [&_li]:gap-1.5 [&_li]:flex-col [&_li]:justify-center  [&_li]:items-center [&_li>h4]:text-14-medium [&_li>span]:text-14-semibold">
+            <li>
+              <div>
+                <MdInsights size={28} />
+              </div>
+              <h4>{t("ScoreSection.performance")}</h4>
+              <span>{data.performanceScore}/100</span>
+            </li>
+            <li className="">
+              <div>
+                <MdInsights size={28} />
+              </div>
+              <h4>{t("ScoreSection.seo")}</h4>
+              <span>{data.seoScore}/100</span>
+            </li>
+            <li>
+              <div>
+                <MdInsights size={28} />
+              </div>
+              <h4>{t("ScoreSection.accessibility")}</h4>
+              <span>{data.accessibilityScore}/100</span>
+            </li>
+
+            <li>
+              <p className="text-20-bold">{data.overallScore}/100</p>
+              <h4>{t("ScoreSection.overall")}</h4>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 개요

- HeroBannerWide 컴포넌트 신규 추가 및 HeroBanner hover 시 툴팁 애니메이션 구현

---

## 작업 상세 내용
- [x] **HeroBannerWide.tsx** 신규 작성 (데스크톱 전용 Hero Banner)
- [x] `framer-motion`의 `AnimatePresence`, `motion.div`를 이용한 fade-in/out 모션 적용
- [x] hover 상태(`onMouseEnter`, `onMouseLeave`)로 툴팁 표시 제어
- [x] `useTranslations`, `useLocale`로 서버 훅(`getTranslations`, `getLocale`) 대체 → 클라이언트 대응


---

## 수정한 파일
- `src/app/[locale]/page.tsx`
- `src/components/domain/home/HeroBanner.tsx`

## 새로 작성한 파일
- `src/components/domain/home/HeroBannerWide.tsx`




---

## 작업 스크린샷

<img width="2170" height="2102" alt="image" src="https://github.com/user-attachments/assets/f15ef879-ed15-42e1-a03d-2ae8e9434a36" />
