### PR TITLE
hotfix: next/link → @/i18n/routing 으로 교체

### DIFF
--- a/src/app/[locale]/projects/[id]/page.tsx
+++ b/src/app/[locale]/projects/[id]/page.tsx
@@ -4,7 +4,7 @@ import Shortcut from "@/components/domain/projects/Shortcut";
 import { Metadata } from "next";
 import { getTranslations, getLocale } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { notFound } from "next/navigation";
 import { MdInsights } from "react-icons/md";
 

--- a/src/components/domain/home/HeroBannerWide.tsx
+++ b/src/components/domain/home/HeroBannerWide.tsx
@@ -2,7 +2,7 @@
 import { ProjectPayload } from "@/types";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import badge from "@/assets/images/badge.svg";
 import { MdInsights } from "react-icons/md";
 import { AnimatePresence, motion } from "framer-motion";


### PR DESCRIPTION
## 작업 개요

- 다국어 페이지 이동 시 locale prefix가 사라지는 버그 수정

---

## 작업 상세 내용

- [x] src/app/[locale]/projects/[id]/page.tsx 에서 Link 교체
- [x] src/components/domain/home/HeroBannerWide.tsx 에서 Link 교체
- [x] 모든 라우팅 시 현재 locale(ko, en)이 유지되도록 수정

---

## 수정한 파일

- `src/app/[locale]/projects/[id]/page.tsx`
- `src/components/domain/home/HeroBannerWide.tsx`
