### PR TITLE
feat(cocreators): 모든 협력자 페이지 및 데이터 로직 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -51,7 +51,8 @@
     "home": "H O M E",
     "about": "A B O U T",
     "contact": "C O N T A C T",
-    "projects": "P R O J E C T S"
+    "projects": "P R O J E C T S",
+    "cocreators": "C O C R E A T O R S"
   },
   "ProjectsPage": {
     "tabs": {
@@ -155,6 +156,9 @@
       "line1": "H I\u00A0\u00A0,\u00A0\u00A0I'M\u00A0\u00A0S U N G H O O N.",
       "line2": "I'M\u00A0\u00A0A\u00A0\u00A0W E B\u00A0\u00A0D E V E L O P E R."
     }
+  },
+  "CocreatorsPage": {
+    "title": "A L L\u00A0\u00A0\u00A0C O C R E A T O R S"
   },
   "Sort": {
     "latest": "L A T E S T",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -51,7 +51,8 @@
     "home": "메 인",
     "about": "소 개",
     "contact": "문 의 하 기",
-    "projects": "프 로 젝 트"
+    "projects": "프 로 젝 트",
+    "cocreators": "혁 력 자 들"
   },
   "ProjectsPage": {
     "tabs": {
@@ -155,6 +156,9 @@
       "line1": "코 드 와\u00A0\u00A0디 자 인 을\u00A0\u00A0잇 는",
       "line2": "크 리 에 이 티 브\u00A0\u00A0개 발 자\u00A0\u00A0“홍 성 훈”"
     }
+  },
+  "CocreatorsPage": {
+    "title": "전 체\u00A0\u00A0\u00A0프 로 젝 트\u00A0\u00A0\u00A0기 여 자 들"
   },
   "Sort": {
     "latest": "최 신 순",

--- a/src/api/readAllCocreators.action.ts
+++ b/src/api/readAllCocreators.action.ts
@@ -2,7 +2,7 @@
 
 import { database } from "@/firebase/firebaseConfig";
 import { get, ref } from "firebase/database";
-import { Participant } from "@/types";
+import { Participant, ProjectPayload } from "@/types";
 
 /**
  * 모든 프로젝트를 순회하며 참여자 목록을 가져옴
@@ -14,23 +14,24 @@ export async function readAllCocreators(): Promise<Participant[]> {
 
   if (!snapshot.exists()) return [];
 
-  const projects = snapshot.val();
+  const projects: Record<string, ProjectPayload> = snapshot.val();
   const allParticipants: Record<string, Participant> = {};
 
-  Object.values(projects).forEach((project: any) => {
+  Object.values(projects).forEach((project) => {
     if (!project.participants) return;
 
-    Object.values(project.participants).forEach((p: any) => {
-      const key = p.githubUrl || p.name;
+    Object.values(project.participants).forEach((p) => {
+      const participant = p as Participant;
+      const key = participant.githubUrl || participant.name;
       if (!allParticipants[key]) {
         allParticipants[key] = {
-          id: p.id,
-          name: p.name,
-          githubUrl: p.githubUrl,
-          imageUrl: p.imageUrl,
-          role: p.role,
-          position: p.position,
-          createdAt: p.createdAt,
+          id: participant.id,
+          name: participant.name,
+          githubUrl: participant.githubUrl,
+          imageUrl: participant.imageUrl,
+          role: participant.role,
+          position: participant.position,
+          createdAt: participant.createdAt,
         };
       }
     });

--- a/src/api/readAllCocreators.action.ts
+++ b/src/api/readAllCocreators.action.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { database } from "@/firebase/firebaseConfig";
+import { get, ref } from "firebase/database";
+import { Participant } from "@/types";
+
+/**
+ * 모든 프로젝트를 순회하며 참여자 목록을 가져옴
+ * 중복 이름 또는 githubUrl 기준으로 중복 제거
+ */
+export async function readAllCocreators(): Promise<Participant[]> {
+  const projectsRef = ref(database, "projects");
+  const snapshot = await get(projectsRef);
+
+  if (!snapshot.exists()) return [];
+
+  const projects = snapshot.val();
+  const allParticipants: Record<string, Participant> = {};
+
+  Object.values(projects).forEach((project: any) => {
+    if (!project.participants) return;
+
+    Object.values(project.participants).forEach((p: any) => {
+      const key = p.githubUrl || p.name;
+      if (!allParticipants[key]) {
+        allParticipants[key] = {
+          id: p.id,
+          name: p.name,
+          githubUrl: p.githubUrl,
+          imageUrl: p.imageUrl,
+          role: p.role,
+          position: p.position,
+          createdAt: p.createdAt,
+        };
+      }
+    });
+  });
+
+  return Object.values(allParticipants);
+}

--- a/src/app/[locale]/cocreators/page.tsx
+++ b/src/app/[locale]/cocreators/page.tsx
@@ -1,0 +1,65 @@
+import { readAllCocreators } from "@/api/readAllCocreators.action";
+import { getTranslations } from "next-intl/server";
+import Image from "next/image";
+
+export default async function CocreatorsPage() {
+  const cocreators = await readAllCocreators();
+  const t = await getTranslations("CocreatorsPage");
+  return (
+    <div className="max-w-258.75 mx-auto">
+      <h1 className="text-16-semibold md:text-20-semibold mb-10 sm:mb-15 md:mb-20">
+        {t("title")}
+      </h1>
+
+      {cocreators.length === 0 ? (
+        <p>No participants found.</p>
+      ) : (
+        <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-20 sm:gap-x-5 sm:gap-y-30 lg:gap-x-[5vw] lg:gap-y-40 md:gap-x-[20vw]">
+          {cocreators.map((c) => (
+            <li key={c.id} className="group">
+              <a
+                href={c.githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={c.name}
+              >
+                <div className="relative aspect-square overflow-hidden">
+                  <Image
+                    src={c.imageUrl || "not found"}
+                    alt={c.name}
+                    fill
+                    sizes="(max-width:768px) 50vw, 25vw"
+                    unoptimized
+                    className="
+                      object-cover w-full h-full
+                      filter
+                      grayscale-[40%] contrast-[1.15] brightness-[0.9]
+                      transition-all duration-500
+                      group-hover:grayscale-0 group-hover:contrast-100 group-hover:brightness-100
+                    "
+                  />
+
+                  {/* hover 시 이름 노출 오버레이 */}
+                  <div
+                    className="
+                      absolute inset-0
+                      flex items-end justify-center
+                      bg-gradient-to-t from-black/60 to-transparent
+                      opacity-0 group-hover:opacity-100
+                      transition-opacity duration-500
+                      p-3
+                    "
+                  >
+                    <span className="text-white text-12-medium sm:text-14-medium lg:text-16-medium">
+                      {c.name}
+                    </span>
+                  </div>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -156,6 +156,14 @@ export default function Header() {
               >
                 {t("projects")}
               </Link>
+
+              <Link
+                href="/cocreators"
+                className={`${baseClasses}`}
+                onClick={() => setIsOpen(false)}
+              >
+                {t("cocreators")}
+              </Link>
               <LocaleSwitcher onClose={() => setIsOpen(false)} />
             </nav>
           </motion.div>


### PR DESCRIPTION
## 작업 개요

- Firebase에 저장된 모든 프로젝트를 순회하여 **참여자(Co-creators) 정보를 통합**하고,
중복 제거 후 한 페이지에서 확인할 수 있는 **Cocreators 페이지**를 추가했습니다.

---

## 작업 상세 내용
- [x] `readAllCocreators.action.ts` 작성
  - `/projects` 전체 순회 → `participants` 병합 → `githubUrl`(우선) 또는 `name` 기준 중복 제거
  - `id, name, githubUrl, imageUrl` 중심으로 반환
- [x] `CocreatorsPage` 추가
  - 서버 컴포넌트에서 비동기 로드 → 그리드 리스트 렌더링
  - 이미지 필터(흑백 톤 + 대비/밝기) 및 hover 시 이름 오버레이 노출
- [x] 헤더 메뉴 및 번역 키 추가 (`en.json`, `ko.json`)

---

## 수정한 파일
- `messages/en.json`
- `messages/ko.json`
- `src/components/layout/Header.tsx`

## 새로 작성한 파일
- `src/api/readAllCocreators.action.ts`
- `src/app/[locale]/cocreators/page.tsx` _(및 폴더)_

---

## 기타 참고 사항
- 대규모 데이터에서는 서버 측 정렬/페이지네이션 고려

---

## 작업 스크린샷

<img width="2351" height="1501" alt="image" src="https://github.com/user-attachments/assets/3c35f470-5f3f-4be4-b872-2ece6282b6b0" />
