### PR TITLE
fix: 언어 전환 시 쿼리스트링(tab, sort 등) 유지되도록 수정

### DIFF
--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { usePathname, useRouter } from "@/i18n/routing";
 import { useLocale } from "next-intl";
+import { useSearchParams } from "next/navigation";
 import { HiMiniSlash } from "react-icons/hi2";
 
 interface Props {
@@ -9,6 +10,7 @@ interface Props {
 
 export default function LocaleSwitcher({ onClose }: Props) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
   const locale = useLocale();
 
@@ -18,7 +20,9 @@ export default function LocaleSwitcher({ onClose }: Props) {
     onClose();
 
     setTimeout(() => {
-      router.push(pathname, { locale: newLocale });
+      const query = searchParams.toString();
+      const url = query ? `${pathname}?${query}` : pathname;
+      router.push(url, { locale: newLocale });
     }, 1000);
   };
 


### PR DESCRIPTION
## 작업 개요

- 언어 변경 시 기존 쿼리스트링(tab, sort 등)이 초기화되는 문제 수정
- LocaleSwitcher 컴포넌트에서 useSearchParams()를 활용해 기존 URL 상태를 유지하도록 개선

---

## 작업 상세 내용
- [x] useSearchParams 훅 추가로 현재 URL의 쿼리스트링 추출
- [x] router.push 시 기존 쿼리 유지하도록 수정
- [x] 언어 전환 시 tab, sort 등의 상태가 초기화되지 않도록 개선

---

## 수정한 파일
- `src/components/layout/LocaleSwitcher.tsx`


