### PR TITLE
feat: 프로젝트 상태 필터 기능 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -129,7 +129,8 @@
     "status": {
       "inProgress": "I N\u00A0\u00A0P R O G R E S S",
       "completed": "C O M P L E T E D"
-    }
+    },
+    "IsProject": "N O\u00A0\u00A0\u00A0P R O J E C T S\u00A0\u00A0\u00A0F O U N D . . ."
   },
   "ContactPage": {
     "title": "Hello. Let’s talk.",
@@ -166,6 +167,8 @@
   },
   "Sort": {
     "latest": "L A T E S T",
-    "oldest": "O L D E S T"
+    "oldest": "O L D E S T",
+    "completed": "C O M P L E T E D",
+    "inProgress": "I N\u00A0\u00A0P R O G R E S S"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -129,7 +129,8 @@
     "status": {
       "inProgress": "진 행\u00A0\u00A0중",
       "completed": "프 로 젝 트\u00A0\u00A0완 료"
-    }
+    },
+    "IsProject": "프 로 젝 트 가\u00A0\u00A0\u00A0없 습 니 다 . . ."
   },
   "ContactPage": {
     "title": "안녕하세요.\u00A0\u00A0문의해 주세요.",
@@ -166,6 +167,8 @@
   },
   "Sort": {
     "latest": "최 신 순",
-    "oldest": "오 래 된 순"
+    "oldest": "오 래 된 순",
+    "completed": "완 성 된\u00A0\u00A0프 로 젝 트",
+    "inProgress": "진 행 중 인\u00A0\u00A0프 로 젝 트"
   }
 }

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -12,8 +12,14 @@ export default async function ProjectsPage({
   searchParams: Promise<{ tab?: string; sort?: SortKey }>;
 }) {
   const { tab, sort } = await searchParams;
-  const validSort: SortKey = sort === "oldest" ? "oldest" : "latest";
 
+  // ✅ 네 가지 정렬 옵션 중 하나만 허용
+  const validSort: SortKey =
+    sort === "oldest" || sort === "completed" || sort === "inProgress"
+      ? sort
+      : "latest";
+
+  // tab이 없을 경우 기본값 지정
   if (!tab) redirect(`?tab=1&sort=${validSort}`);
 
   let content: React.ReactNode;

--- a/src/components/domain/projects/AllProjectsTab.tsx
+++ b/src/components/domain/projects/AllProjectsTab.tsx
@@ -1,16 +1,18 @@
 import { readAllProjects } from "@/api/readAllProjects.action";
 import ProjectCard from "@/components/common/ProjectCard";
 import { SortKey, sortProjects } from "@/utils";
+import { getTranslations } from "next-intl/server";
 
 export default async function AllProjectsTab({ sort }: { sort: SortKey }) {
   const datas = await readAllProjects();
   const sorted = sortProjects(datas, sort);
+  const t = await getTranslations("ProjectsPage");
 
   return (
     <>
       {sorted.length === 0 ? (
         <div className="text-center text-14-medium md:text-16-medium">
-          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+          {t("IsProject")}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-14 md:grid-cols-2 md:items-start justify-items-center lg:grid-cols-3 lg:gap-y-25">

--- a/src/components/domain/projects/PersonalProjectsTab.tsx
+++ b/src/components/domain/projects/PersonalProjectsTab.tsx
@@ -1,16 +1,18 @@
 import { readPersonalProjects } from "@/api/readPersonalProjects.action";
 import ProjectCard from "@/components/common/ProjectCard";
 import { SortKey, sortProjects } from "@/utils";
+import { getTranslations } from "next-intl/server";
 
 export default async function PersonalProjectsTab({ sort }: { sort: SortKey }) {
   const datas = await readPersonalProjects();
   const sorted = sortProjects(datas, sort);
+  const t = await getTranslations("ProjectsPage");
 
   return (
     <>
       {sorted.length === 0 ? (
         <div className="text-center text-14-medium md:text-16-medium">
-          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+          {t("IsProject")}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-14 md:grid-cols-2 md:items-start justify-items-center lg:grid-cols-3 lg:gap-y-25">

--- a/src/components/domain/projects/SortSelector.tsx
+++ b/src/components/domain/projects/SortSelector.tsx
@@ -23,32 +23,21 @@ export default function SortSelector({
 
   return (
     <div className="flex justify-end mb-6 sm:mb-10">
-      <div className="relative inline-block">
+      <div className="w-fit relative inline">
         <select
           value={currentSort}
           onChange={(e) => {
             handleChange(e);
             e.target.blur();
           }}
-          className="
-        appearance-none
-        px-4 py-2.5 pr-10
-        text-14-medium
-        rounded-lg
-        bg-white 
-        border border-gray-200 
-        dark:text-gray-100
-        shadow-sm
-        hover:border-gray-400 
-        transition-all duration-200
-        cursor-pointer
-      "
+          className=" appearance-none px-4 py-2.5 pr-10 text-14-medium rounded-lg bg-white border border-gray-200 dark:text-gray-100 shadow-sm hover:border-gray-400 transition-all duration-200 cursor-pointer"
         >
           <option value="latest">{t("latest")}</option>
           <option value="oldest">{t("oldest")}</option>
+          <option value="completed">{t("completed")}</option>
+          <option value="inProgress">{t("inProgress")}</option>
         </select>
 
-        {/* ▼ 커스텀 화살표 아이콘 */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"

--- a/src/components/domain/projects/TeamProjectsTab.tsx
+++ b/src/components/domain/projects/TeamProjectsTab.tsx
@@ -1,16 +1,18 @@
 import { readTeamProjects } from "@/api/readTeamProjects.action";
 import ProjectCard from "@/components/common/ProjectCard";
 import { SortKey, sortProjects } from "@/utils";
+import { getTranslations } from "next-intl/server";
 
 export default async function TeamProjectsTab({ sort }: { sort: SortKey }) {
   const datas = await readTeamProjects();
   const sorted = sortProjects(datas, sort);
+  const t = await getTranslations("ProjectsPage");
 
   return (
     <>
       {sorted.length === 0 ? (
         <div className="text-center text-14-medium md:text-16-medium">
-          N O&nbsp;&nbsp;&nbsp;P R O J E C T S&nbsp;&nbsp;&nbsp;F O U N D . . .
+          {t("IsProject")}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-14 md:grid-cols-2 md:items-start justify-items-center lg:grid-cols-3 lg:gap-y-25">

--- a/src/utils/sortProjects.ts
+++ b/src/utils/sortProjects.ts
@@ -1,4 +1,4 @@
-export type SortKey = "latest" | "oldest";
+export type SortKey = "latest" | "oldest" | "completed" | "inProgress";
 
 type MaybeDate = string | number | Date;
 
@@ -15,12 +15,26 @@ function toTime(value?: MaybeDate) {
 }
 
 /** createdAt 기준 정렬 (필요 시 updatedAt으로 변경) */
-export function sortProjects<T extends ProjectLike>(items: T[], sort: SortKey): T[] {
+export function sortProjects<T extends ProjectLike & { isCompleted?: boolean }>(
+  items: T[],
+  sort: SortKey
+): T[] {
   const arr = [...items];
-  if (sort === "latest") {
-    arr.sort((a, b) => toTime(b.createdAt) - toTime(a.createdAt));
-  } else {
-    arr.sort((a, b) => toTime(a.createdAt) - toTime(b.createdAt));
+
+  switch (sort) {
+    case "latest":
+      return arr.sort((a, b) => toTime(b.createdAt) - toTime(a.createdAt));
+    case "oldest":
+      return arr.sort((a, b) => toTime(a.createdAt) - toTime(b.createdAt));
+    case "completed":
+      return arr
+        .filter((p) => p.isCompleted)
+        .sort((a, b) => toTime(b.createdAt) - toTime(a.createdAt));
+    case "inProgress":
+      return arr
+        .filter((p) => !p.isCompleted)
+        .sort((a, b) => toTime(b.createdAt) - toTime(a.createdAt));
+    default:
+      return arr;
   }
-  return arr;
 }


### PR DESCRIPTION
## 작업 개요

- 프로젝트 카드 목록에 **상태 필터 기능** 추가  
- 사용자가 진행 중 / 완료된 프로젝트를 구분해서 볼 수 있도록 개선  

---

## 작업 상세 내용
- [x] `SortSelector` 컴포넌트 내 상태 필터 옵션 추가 (`inProgress`, `completed`)  
- [x] 상태값을 기반으로 필터링된 프로젝트 리스트 표시  

---

## 수정한 파일

- `messages/en.json`  
- `messages/ko.json`  
- `src/app/[locale]/projects/page.tsx`  
- `src/components/domain/projects/AllProjectsTab.tsx`  
- `src/components/domain/projects/PersonalProjectsTab.tsx`  
- `src/components/domain/projects/SortSelector.tsx`  
- `src/components/domain/projects/TeamProjectsTab.tsx`  
- `src/utils/sortProjects.ts`  



