### PR TITLE
chore(i18n): 홈 최신 프로젝트 타이틀 연도 2026으로 갱신

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -36,7 +36,7 @@
     "imageAlt": "Project Preview Image"
   },
   "HomePage": {
-    "title": "M Y\u00A0\u00A0\u00A0L A T E S T\u00A0\u00A0\u00A0P R O J E C T\u00A0\u00A0\u00A02 0 2 5",
+    "title": "M Y\u00A0\u00A0\u00A0L A T E S T\u00A0\u00A0\u00A0P R O J E C T\u00A0\u00A0\u00A02 0 2 6",
     "teamProjectLink": "T E A M\u00A0\u00A0\u00A0P R O J E C T S",
     "personalProjectLink": "P E R S O N A L\u00A0\u00A0\u00A0P R O J E C T S",
     "more": "M\u00A0\u00A0O\u00A0\u00A0R\u00A0\u00A0\u00A0E",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -36,7 +36,7 @@
     "imageAlt": "프로젝트 미리보기 이미지"
   },
   "HomePage": {
-    "title": "2 0 2 5 년\u00A0\u00A0\u00A0나 의\u00A0\u00A0\u00A0최 신\u00A0\u00A0\u00A0작 업 물",
+    "title": "2 0 2 6 년\u00A0\u00A0\u00A0나 의\u00A0\u00A0\u00A0최 신\u00A0\u00A0\u00A0작 업 물",
     "teamProjectLink": "팀\u00A0\u00A0\u00A0프 로 젝 트",
     "personalProjectLink": "개 인\u00A0\u00A0\u00A0프 로 젝 트",
     "more": "전 체\u00A0\u00A0\u00A0프 로 젝 트",


### PR DESCRIPTION
## 작업 개요

- 홈 페이지 히어로 타이틀에 표시되는 연도를 2026년 기준으로 반영 (한·영)

---

## 작업 상세 내용

- [x] `messages/en.json` — `HomePage.title` 연도 2026으로 수정
- [x] `messages/ko.json` — `HomePage.title` 연도 2026으로 수정

---

## 수정한 파일

- `messages/en.json`
- `messages/ko.json`

## 새로 작성한 파일

- 없음

---

## 기타 참고 사항

- UI 레이아웃·컴포넌트 변경 없음 (문구 번역 문자열만 수정)